### PR TITLE
feat: bump release status to GA

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -4,7 +4,7 @@
   "product_documentation": "https://cloud.google.com/text-to-speech",
   "client_documentation": "https://googleapis.dev/python/texttospeech/latest",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/5235428",
-  "release_level": "alpha",
+  "release_level": "ga",
   "language": "python",
   "repo": "googleapis/python-texttospeech",
   "distribution_name": "google-cloud-texttospeech",

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Python Client for Cloud Text-to-Speech API
 ==========================================
 
-|alpha| |pypi| |versions| 
+|GA| |pypi| |versions| 
 
 `Cloud Text-to-Speech API`_: Synthesizes natural-sounding speech by applying
 powerful neural network models.
@@ -9,8 +9,8 @@ powerful neural network models.
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. |alpha| image:: https://img.shields.io/badge/support-alpha-orange.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#alpha-support
+.. |GA| image:: https://img.shields.io/badge/support-GA-gold.svg
+   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-texttospeech.svg
    :target: https://pypi.org/project/google-cloud-texttospeech/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-texttospeech.svg

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ version = "0.5.0"
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
-release_status = "Development Status :: 3 - Alpha"
+release_status = "Development Status :: 5 - Production/Stable"
 dependencies = ["google-api-core[grpc] >= 1.14.0, < 2.0.0dev"]
 extras = {}
 


### PR DESCRIPTION
Release-As: 1.0.0

The underlying API is GA.

[GA release template](https://github.com/googleapis/google-cloud-common/issues/287)
## Required 

- [x] 28 days elapsed since last beta release with new API surface
- [x] Server API is GA
- [x] Package API is stable, and we can commit to backward compatibility
- [x] All dependencies are GA
