### PR TITLE
chore: tweaks and moves CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,4 @@
 
 
 # The python-samples-owners team is the default owner for samples
-*                               @googleapis/python-samples-owners
-
-/samples/                       @telpirion @sirtorry @googleapis/python-samples-owners
+/samples/**/*.py                       @telpirion @sirtorry @googleapis/python-samples-owners


### PR DESCRIPTION
Moves CODEOWNERS from root to .github/

Tweaks /samples/ ownership (narrows to *.py)