### PR TITLE
docs: create docfx yaml files and upload them

### DIFF
--- a/.kokoro/publish-docs.sh
+++ b/.kokoro/publish-docs.sh
@@ -43,3 +43,23 @@ cat docs.metadata
 
 # upload docs
 python3 -m docuploader upload docs/_build/html --metadata-file docs.metadata --staging-bucket "${STAGING_BUCKET}"
+
+
+# docfx yaml files
+nox -s docfx
+
+# create metadata.
+python3 -m docuploader create-metadata \
+  --name=$(jq --raw-output '.name // empty' .repo-metadata.json) \
+  --version=$(python3 setup.py --version) \
+  --language=$(jq --raw-output '.language // empty' .repo-metadata.json) \
+  --distribution-name=$(python3 setup.py --name) \
+  --product-page=$(jq --raw-output '.product_documentation // empty' .repo-metadata.json) \
+  --github-repository=$(jq --raw-output '.repo // empty' .repo-metadata.json) \
+  --issue-tracker=$(jq --raw-output '.issue_tracker // empty' .repo-metadata.json) \
+  --serving-path="/python/docs/reference/$(jq --raw-output '.name // empty' .repo-metadata.json)/$(jq --raw-output '.distribution_name // empty' .repo-metadata.json)/latest"
+
+cat docs.metadata
+
+# upload docs
+python3 -m docuploader upload docs/_build/html/docfx_yaml --metadata-file docs.metadata --destination-prefix docfx- --staging-bucket "${STAGING_BUCKET}"

--- a/noxfile.py
+++ b/noxfile.py
@@ -155,3 +155,35 @@ def docs(session):
         os.path.join("docs", ""),
         os.path.join("docs", "_build", "html", ""),
     )
+
+@nox.session(python=DEFAULT_PYTHON_VERSION)
+def docfx(session):
+    """Build the docfx yaml files for this library."""
+
+    session.install("-e", ".")
+    session.install("sphinx", "alabaster", "recommonmark", "sphinx-docfx-yaml")
+
+    shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
+    session.run(
+        "sphinx-build",
+        "-T",  # show full traceback on exception
+        "-N",  # no colors
+        "-D",
+        (
+            "extensions=sphinx.ext.autodoc,"
+            "sphinx.ext.autosummary,"
+            "docfx_yaml.extension,"
+            "sphinx.ext.intersphinx,"
+            "sphinx.ext.coverage,"
+            "sphinx.ext.napoleon,"
+            "sphinx.ext.todo,"
+            "sphinx.ext.viewcode,"
+            "recommonmark"
+        ),
+        "-b",
+        "html",
+        "-d",
+        os.path.join("docs", "_build", "doctrees", ""),
+        os.path.join("docs", ""),
+        os.path.join("docs", "_build", "html", ""),
+    )

--- a/noxfile.py
+++ b/noxfile.py
@@ -156,6 +156,7 @@ def docs(session):
         os.path.join("docs", "_build", "html", ""),
     )
 
+
 @nox.session(python=DEFAULT_PYTHON_VERSION)
 def docfx(session):
     """Build the docfx yaml files for this library."""


### PR DESCRIPTION
This PR preserves the current behavior for uploading the HTML.

It will generate docfx yaml files and upload them with docfx prefix. I confirmed that the doc-pipeline job can create html files from the uploaded yaml files.

cc @tbpg

