### PR TITLE
chore: assign googleapis/cdpe-cloudai as codeowner

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -12,5 +12,5 @@
     "api_id": "texttospeech.googleapis.com",
     "requires_billing": true,
     "default_version": "v1",
-    "codeowner_team": ""
+    "codeowner_team": "@googleapis/cdpe-cloudai"
 }


### PR DESCRIPTION
assign @googleapis/cdpe-cloudai as codeowner
