### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "texttospeech",
     "name_pretty": "Google Cloud Text-to-Speech",
     "product_documentation": "https://cloud.google.com/text-to-speech",
-    "client_documentation": "https://googleapis.dev/python/texttospeech/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/texttospeech/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/5235428",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ powerful neural network models.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-texttospeech.svg
    :target: https://pypi.org/project/google-cloud-texttospeech/
 .. _Cloud Text-to-Speech API: https://cloud.google.com/texttospeech
-.. _Client Library Documentation: https://googleapis.dev/python/texttospeech/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/texttospeech/latest
 .. _Product Documentation: https://cloud.google.com/texttospeech
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.