### PR TITLE
chore: make samples 3.6 check optional

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -10,6 +10,5 @@ branchProtectionRules:
     - 'Kokoro'
     - 'cla/google'
     - 'Samples - Lint'
-    - 'Samples - Python 3.6'
     - 'Samples - Python 3.7'
     - 'Samples - Python 3.8'


### PR DESCRIPTION
3.6 went end-of-life in December